### PR TITLE
fix output format

### DIFF
--- a/langevin.cc
+++ b/langevin.cc
@@ -26,8 +26,7 @@ Langevin::Run(MDManager *mdm) {
       mout << mdm->GetSimulationTime();
       mout << " " << mdm->Temperature();
       mout << " " << mdm->Pressure();
-      mout << " " << mdm->TotalEnergy();
-      mout << "# observe" << std::endl;
+      mout << " " << mdm->TotalEnergy() << std::endl;
     }
   }
 }


### PR DESCRIPTION
以下のように出力時の`#`の位置が正しくなく、数値としてパースできない問題がありました。

```
0.005 1.07972 -4.15393 -3.09008# observe
0.505 0.824853 -1.51301 -3.27591# observe
1.005 0.955519 -1.01765 -3.17738# observe
1.505 1.05484 -0.590952 -3.1132# observe
```

文字列を削除するようにしました。この方がnumpyの`loadtxt`メソッドをそのまま使えるので扱いやすいです。もし文字列を残す方がよければ`#`の位置のみ修正していただければと思います。

```
0.005 1.07972 -4.15393 -3.09008
0.505 0.824853 -1.51301 -3.27591
1.005 0.955519 -1.01765 -3.17738
```